### PR TITLE
fix(ci): tolerate missing log files + feat: donor→principal bridge

### DIFF
--- a/.github/actions/report-failure/action.yml
+++ b/.github/actions/report-failure/action.yml
@@ -1,0 +1,73 @@
+name: "Report Pipeline Failure"
+description: "Collect whatever logs exist into a single report and open a GitHub issue. Tolerates missing log files."
+
+inputs:
+  title:
+    description: "Issue title"
+    required: true
+  labels:
+    description: "Comma-separated labels"
+    required: true
+  primary-log:
+    description: "Preferred log path to surface at top of report (optional)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Collect logs into failure report
+      shell: bash
+      run: |
+        set -u
+        mkdir -p data/logs
+        REPORT=data/logs/failure_report.md
+        {
+          echo "# Pipeline failure report"
+          echo ""
+          echo "- workflow: ${GITHUB_WORKFLOW}"
+          echo "- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "- commit: ${GITHUB_SHA}"
+          echo "- triggered by: ${GITHUB_EVENT_NAME}"
+          echo ""
+        } > "$REPORT"
+
+        PRIMARY="${{ inputs.primary-log }}"
+        if [ -n "$PRIMARY" ] && [ -f "$PRIMARY" ]; then
+          {
+            echo "## Primary log: $PRIMARY (last 200 lines)"
+            echo ""
+            echo '```'
+            tail -n 200 "$PRIMARY"
+            echo '```'
+            echo ""
+          } >> "$REPORT"
+        fi
+
+        LOGS=$(find data/logs -maxdepth 2 -name '*.log' 2>/dev/null | sort)
+        if [ -z "$LOGS" ]; then
+          echo "_No log files found in data/logs/. The failure likely occurred before any pipeline script produced output — check the workflow run link above._" >> "$REPORT"
+        else
+          for f in $LOGS; do
+            if [ "$f" = "$PRIMARY" ]; then
+              continue
+            fi
+            {
+              echo "## $f (last 80 lines)"
+              echo ""
+              echo '```'
+              tail -n 80 "$f"
+              echo '```'
+              echo ""
+            } >> "$REPORT"
+          done
+        fi
+
+        echo "Report written to $REPORT ($(wc -l < "$REPORT") lines)"
+
+    - name: Open issue from report
+      uses: peter-evans/create-issue-from-file@v5
+      with:
+        title: ${{ inputs.title }}
+        content-filepath: data/logs/failure_report.md
+        labels: ${{ inputs.labels }}

--- a/.github/workflows/daily-contributions.yml
+++ b/.github/workflows/daily-contributions.yml
@@ -47,8 +47,8 @@ jobs:
           script: 41_load_contributions.py
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:medium] daily-contributions"
-          content-filepath: data/logs/03_scrape_contributions.py.log
           labels: pipeline-failure,severity:medium,data-update
+          primary-log: data/logs/03_scrape_contributions.py.log

--- a/.github/workflows/daily-expenditures.yml
+++ b/.github/workflows/daily-expenditures.yml
@@ -99,8 +99,8 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:medium] daily-expenditures"
-          content-filepath: data/logs/04_scrape_expenditures.py.log
           labels: pipeline-failure,severity:medium,data-update
+          primary-log: data/logs/04_scrape_expenditures.py.log

--- a/.github/workflows/daily-fl-lobbyist.yml
+++ b/.github/workflows/daily-fl-lobbyist.yml
@@ -91,8 +91,8 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:medium] daily-fl-lobbyist"
-          content-filepath: data/logs/47b_refresh_lobbyist_comp.py.log
           labels: pipeline-failure,severity:medium,data-update
+          primary-log: data/logs/47b_refresh_lobbyist_comp.py.log

--- a/.github/workflows/daily-new-committees.yml
+++ b/.github/workflows/daily-new-committees.yml
@@ -37,10 +37,10 @@ jobs:
           script: 05b_upsert_committees_supabase.py
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         env:
           RUN_ID: ${{ github.run_id }}
         with:
           title: "[pipeline-failure:high] daily-new-committees"
-          content-filepath: data/logs/02_download_registry.py.log
           labels: pipeline-failure,severity:high,data-update
+          primary-log: data/logs/02_download_registry.py.log

--- a/.github/workflows/expend-exe-watchdog.yml
+++ b/.github/workflows/expend-exe-watchdog.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Open issue if down
         if: steps.probe.outputs.status == 'down'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[data-source-down] expend.exe non-200"
-          content-filepath: data/logs/expend_watchdog.log
           labels: pipeline-failure,data-source-down,severity:high
+          primary-log: data/logs/expend_watchdog.log

--- a/.github/workflows/fec-indiv-load.yml
+++ b/.github/workflows/fec-indiv-load.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:medium] fec-indiv-load"
-          content-filepath: data/logs/105_load_fec_indiv_fl.py.log
           labels: pipeline-failure,severity:medium,data-update
+          primary-log: data/logs/105_load_fec_indiv_fl.py.log

--- a/.github/workflows/fec-oth-load.yml
+++ b/.github/workflows/fec-oth-load.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:medium] fec-oth-load"
-          content-filepath: data/logs/106_load_fec_oth_fl.py.log
           labels: pipeline-failure,severity:medium,data-update
+          primary-log: data/logs/106_load_fec_oth_fl.py.log

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -33,8 +33,8 @@ jobs:
         with: { script: 99_smoke_test.py }
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:high] nightly-smoke"
-          content-filepath: data/logs/99_smoke_test.py.log
           labels: pipeline-failure,severity:high,smoke-test
+          primary-log: data/logs/99_smoke_test.py.log

--- a/.github/workflows/quarterly-full-refresh.yml
+++ b/.github/workflows/quarterly-full-refresh.yml
@@ -101,8 +101,8 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:high] quarterly-full-refresh"
-          content-filepath: data/logs/84_audit_data_integrity.py.log
           labels: pipeline-failure,severity:high,data-update
+          primary-log: data/logs/84_audit_data_integrity.py.log

--- a/.github/workflows/weekly-legislature.yml
+++ b/.github/workflows/weekly-legislature.yml
@@ -63,8 +63,8 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:medium] weekly-legislature"
-          content-filepath: data/logs/75_update_legislator_stats.py.log
           labels: pipeline-failure,severity:medium,data-update
+          primary-log: data/logs/75_update_legislator_stats.py.log

--- a/.github/workflows/weekly-transfers.yml
+++ b/.github/workflows/weekly-transfers.yml
@@ -36,8 +36,8 @@ jobs:
           script: 11_scrape_transfers.py
       - name: Open issue on failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: ./.github/actions/report-failure
         with:
           title: "[pipeline-failure:low] weekly-transfers"
-          content-filepath: data/logs/11_scrape_transfers.py.log
           labels: pipeline-failure,severity:low,data-update
+          primary-log: data/logs/11_scrape_transfers.py.log

--- a/app/api/follow/route.js
+++ b/app/api/follow/route.js
@@ -98,6 +98,30 @@ export async function GET(req) {
     return NextResponse.json({ candidates });
   }
 
+  // ── Donor → Principals (lobbying-side identity match) ────────────────────
+  // Phase 1 of the "dream use case". Surfaces principal_donation_matches rows
+  // >= 85 score so /follow can pivot from a corporate donor to the principal
+  // that lobbies the legislature under a matching name.
+  if (step === 'principals') {
+    const slug = searchParams.get('donor_slug') || searchParams.get('slug');
+    if (!slug) return NextResponse.json({ error: 'donor_slug required' }, { status: 400 });
+
+    const { data } = await db
+      .from('donor_principal_links_v')
+      .select('principal_slug, principal_name, match_score')
+      .eq('donor_slug', slug)
+      .order('match_score', { ascending: false })
+      .limit(20);
+
+    return NextResponse.json({
+      principals: (data || []).map(r => ({
+        slug:  r.principal_slug,
+        name:  r.principal_name,
+        score: parseFloat(r.match_score) || 0,
+      })),
+    });
+  }
+
   // ── Candidate → Votes ─────────────────────────────────────────────────────
   if (step === 'votes') {
     const acct = searchParams.get('acct');

--- a/supabase/migrations/047_donor_principal_links.sql
+++ b/supabase/migrations/047_donor_principal_links.sql
@@ -1,0 +1,35 @@
+-- 047_donor_principal_links.sql
+-- Phase 1 of /follow "dream use case": expose donor → principal links as a view.
+--
+-- principal_donation_matches already holds 135,884 fuzzy-matched rows keyed by
+-- (principal_slug, contributor_name). donors_mv holds canonical donor rows.
+-- This view joins the two so /follow can answer "which principals match this
+-- donor?" without client-side fuzzy logic.
+--
+-- Threshold 85 drops the noisiest fuzzy matches (see principal_donation_matches
+-- match_score distribution — <85 is overwhelmingly false positives like
+-- "FLORIDA CULTURAL ALLIANCE" → "THE FLORIDA ALLIANCE").
+
+CREATE OR REPLACE VIEW donor_principal_links_v AS
+SELECT
+  d.slug                    AS donor_slug,
+  d.name                    AS donor_name,
+  p.slug                    AS principal_slug,
+  p.name                    AS principal_name,
+  pdm.match_score
+FROM principal_donation_matches pdm
+JOIN donors_mv d   ON UPPER(d.name) = UPPER(pdm.contributor_name)
+JOIN principals p  ON p.slug = pdm.principal_slug
+WHERE pdm.match_score >= 85;
+
+COMMENT ON VIEW donor_principal_links_v IS
+  'Donor→Principal bridge for /follow. Joins principal_donation_matches (fuzzy) with donors_mv + principals. Threshold match_score>=85 drops noise. Note: total_donated / num_contributions were intentionally excluded — those columns in principal_donation_matches are aggregated per-principal, not per-(donor,principal), and would mislead consumers. Compute donor-level spend from contributions directly.';
+
+-- Supporting index to make donor-side lookup fast.
+-- donors_mv.name is already trigram-indexed (migration 042); we need a
+-- functional UPPER(name) btree to speed the equality join here.
+CREATE INDEX IF NOT EXISTS idx_donors_mv_upper_name
+  ON donors_mv (UPPER(name));
+
+CREATE INDEX IF NOT EXISTS idx_pdm_upper_contributor
+  ON principal_donation_matches (UPPER(contributor_name));


### PR DESCRIPTION
## Summary

- **fix(ci)**: 11 workflows rewired to a new `.github/actions/report-failure` composite action. Yesterday's daily-contributions run erred on the issue-filer step because `data/logs/03_scrape_contributions.py.log` didn't exist — the new action scans whatever logs are present and falls back to a stub when none are.
- **feat(follow) Phase 1**: new view `donor_principal_links_v` (migration 047) + new `/api/follow?step=principals` step. 53,772 link rows, 83% of principals covered. Applied to Supabase live.

## Test plan

- [x] YAML lint across all 13 workflow + action files (clean)
- [x] Migration 047 applied to Supabase; view returns 53,772 rows
- [x] `donor_slug=florida-power-light-company` → FPL principal, score 100
- [ ] Next scheduled daily-contributions run exercises the new failure-report action if any step fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)